### PR TITLE
feat: add-msvc-support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,10 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
   cmake_policy(SET CMP0135 NEW)
 endif()
 
+if(MSVC)
+  set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "Available configuration types to select")
+endif()
+
 add_library(cpp_peglib INTERFACE)
 target_include_directories(cpp_peglib INTERFACE include)
 target_compile_features(cpp_peglib INTERFACE cxx_std_20)
@@ -12,6 +16,10 @@ target_compile_features(cpp_peglib INTERFACE cxx_std_20)
 option(PEGLIB_BUILD_TESTS "Build cpp-peglib tests" OFF)
 option(PEGLIB_BUILD_LINT "Build cpp-peglib lint" OFF)
 option(PEGLIB_BUILD_EXAMPLE "Build cpp-peglib example" OFF)
+
+target_compile_options(cpp_peglib INTERFACE
+  $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:MSVC>>:/Zc:__cplusplus /utf-8>
+)
 
 if(${PEGLIB_BUILD_LINT})
   add_subdirectory(lint)


### PR DESCRIPTION
## Add support for Microsoft Visual C/C++

* Update CMakeLists.txt for MSVC.

* Fix MSVC compiler issues: `/utf-8`, `/Zc:__cplusplus`

* Set the default `CMAKE_CONFIGURATION_TYPES` to `Debug;Release` for MSVC. This is required because MSVC is a [multi-config](https://cmake.org/cmake/help/latest/prop_gbl/GENERATOR_IS_MULTI_CONFIG.html) CMake generator. Otherwise the property defaults to empty, and nothing gets built.

### List of Pull Requests

There are a total of seven PRs, one for each repository: cuda-battery, lala-core, lala-parsing, lala-pc, lala-power, and cpp-peglib, and turbo. The PRs need to be applied simultaneously.